### PR TITLE
Re-add the cors lines for actix

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -3,6 +3,7 @@ use super::mavlink_vehicle::MAVLinkVehicleArcMutex;
 
 use paperclip::actix::{web, OpenApiExt};
 
+use actix_cors::Cors;
 use actix_web::{
     error::{ErrorBadRequest, JsonPayloadError},
     rt::System,
@@ -28,6 +29,7 @@ pub fn run(server_address: &str, mavlink_vehicle: &MAVLinkVehicleArcMutex) {
     let _ = System::new("http-server");
     HttpServer::new(move || {
         App::new()
+            .wrap(Cors::default())
             // Record services and routes for paperclip OpenAPI plugin for Actix.
             .wrap_api()
             //TODO Add middle man to print all http events

--- a/src/server.rs
+++ b/src/server.rs
@@ -29,7 +29,7 @@ pub fn run(server_address: &str, mavlink_vehicle: &MAVLinkVehicleArcMutex) {
     let _ = System::new("http-server");
     HttpServer::new(move || {
         App::new()
-            .wrap(Cors::default())
+            .wrap(Cors::permissive())
             // Record services and routes for paperclip OpenAPI plugin for Actix.
             .wrap_api()
             //TODO Add middle man to print all http events


### PR DESCRIPTION
Adds lines previously added to fix cors issues, but subsequently lost presumably due to a code rewrite. Fixes https://github.com/patrickelectric/mavlink2rest/issues/61 by reimplementing historical fix https://github.com/patrickelectric/mavlink2rest/commit/5964e2dc250b7ccd0614befcb6a2b99e4e41843f as mentioned in https://github.com/patrickelectric/mavlink2rest/issues/12.